### PR TITLE
Clarify OV supply conditions & Remove repeated auditor quote

### DIFF
--- a/docs/Concepts Explained/OI caps and other caps.md
+++ b/docs/Concepts Explained/OI caps and other caps.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 ## Introduction
 
-Overlay uses its native token OV to pay out PnL if there is a loss, and burns OV collateralized by the user (up to the extent of the loss) in case of a loss. While this mechanism bestows the protocol with benefits like not requiring market makers or the ability to open positions on nearly any scalar data stream, it also opens the protocol up to potential vulnerabilities caused by OV inflation (especially in case of long-tail assets).
+Overlay uses its native token OV to pay out PnL. In case of a profit, it mints OV to be rewarded to the winner. Consequently, in case of a loss, it burns the OV collateralized by the user (up to the extent of the loss). While this mechanism bestows the protocol with benefits like not requiring market makers or the ability to open positions on nearly any scalar data stream, it also opens the protocol up to potential vulnerabilities caused by OV inflation (especially in case of long-tail assets).
 
 To counter these potential vulnerabilities, Overlay utilizes a risk framework that includes payoff caps, OI caps, and a circuit breaker mechanism.
 

--- a/docs/Security/Third party audits.md
+++ b/docs/Security/Third party audits.md
@@ -86,16 +86,14 @@ There are some selected excerpts below:
 
 From the “General Comments” section:
 
-_“…Our team attempted to force existing positions to become liquidatable by executing a flash loan attack. The attack attempted to build large subsequent positions that would cause the existing positions to lose value. However, the attack was thwarted by the circuit breaker defense. We observed that the risk parameters maintenanceMarginFraction and liquidationFeeRate are critical in preventing flash loan attacks and should be set carefully by a secure governance mechanism._
-
-_We also attempted to create many small positions as an alternative vector to manipulate the value of existing positions but found that the gas cost was prohibitive. Given that the ability to access the feed creation mechanism is unguarded, we explored the potential for griefing attacks but did not identify any issues. Our team found the protocol to be well designed and implemented. However, the project is based on complex finance structures that increased the auditing complexity substantially.”_
+>_“…Our team attempted to force existing positions to become liquidatable by executing a flash loan attack. The attack attempted to build large subsequent positions that would cause the existing positions to lose value. However, the attack was thwarted by the circuit breaker defense. We observed that the risk parameters maintenanceMarginFraction and liquidationFeeRate are critical in preventing flash loan attacks and should be set carefully by a secure governance mechanism._
+>
+>_We also attempted to create many small positions as an alternative vector to manipulate the value of existing positions but found that the gas cost was prohibitive. Given that the ability to access the feed creation mechanism is unguarded, we explored the potential for griefing attacks but did not identify any issues. Our team found the protocol to be well designed and implemented. However, the project is based on complex finance structures that increased the auditing complexity substantially.”_
 
 From the “System Design” section:
 
-_“We found that security has been taken into consideration in the design of the Overlay protocol as demonstrated by a careful delineation of roles and the authority granted to them. Our team noted that sufficient input validation has been implemented where appropriate, in addition to mechanisms that hinder attacks, such as caps, spreads, and market-specific parameters set by protocol governance… “_
-
-_The Overlay code is well organized and adheres to best practices as demonstrated by optimizing storage space by rationally assigning storage variables, moving logic into libraries to minimize the code, appropriately using the require function to ensure the validity of contract state transitions, and also using interfaces to improve readability and facilitate reasoning about the code by abstracting code functionality…”_
+>_“We found that security has been taken into consideration in the design of the Overlay protocol as demonstrated by a careful delineation of roles and the authority granted to them. Our team noted that sufficient input validation has been implemented where appropriate, in addition to mechanisms that hinder attacks, such as caps, spreads, and market-specific parameters set by protocol governance… “_
 
 From the “Code Quality” section:
 
-_The Overlay code is well organized and adheres to best practices as demonstrated by optimizing storage space by rationally assigning storage variables, moving logic into libraries to minimize the code, appropriately using the require function to ensure the validity of contract state transitions, and also using interfaces to improve readability and facilitate reasoning about the code by abstracting code functionality._
+>_"The Overlay code is well organized and adheres to best practices as demonstrated by optimizing storage space by rationally assigning storage variables, moving logic into libraries to minimize the code, appropriately using the require function to ensure the validity of contract state transitions, and also using interfaces to improve readability and facilitate reasoning about the code by abstracting code functionality."_


### PR DESCRIPTION
This PR fixes a few typos. In particular it makes the following changes:

- The section on OV minting based on user PnL was fixed to convey the intended meaning. Earlier, both scenarios were labeled as 'loss'

- A repeated quote from the _Least Authority_ audit under a non-related heading was removed.

- Blockquote styling was introduced for highlighting direct quotes from the audit report